### PR TITLE
refs qorelanguage/qore#1767 some fixes for Darwin, still not working …

### DIFF
--- a/test/process.qtest
+++ b/test/process.qtest
@@ -1,4 +1,5 @@
 #!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
 
 %new-style
 
@@ -9,10 +10,15 @@
 
 # to be used in static methods and separate functions
 our *softbool VERBOSE;
-our object MAIN; # sort of hack...
+our Main MAIN; # sort of hack...
 
 
 public class Main inherits QUnit::Test {
+
+    private {
+        # prefix to find other test scripts
+        string m_pfx = get_script_dir() + DirSep;
+    }
 
     constructor() : Test("Process", "1.0") {
         VERBOSE = m_options.verbose;
@@ -47,7 +53,8 @@ public class Main inherits QUnit::Test {
 
     searchPathTest() {
         any s = Process::searchPath("ls");
-        assertEq("/usr/bin/ls", s, "searchPath for ls");
+        # heuristic to find ls
+        assertEq(dirname(ENV.SHELL) + "/ls", s, "searchPath for ls");
 
         try {
             Process::searchPath("some-not-existing-exec");
@@ -227,7 +234,7 @@ public class Main inherits QUnit::Test {
         hash opts = (
                 "path" : ( absolute_path("."), ),
             );
-        Process p("test_io.q", opts);
+        Process p(m_pfx + "test_io.q", opts);
         p.write(str);
 
         int ix = 0;
@@ -282,12 +289,12 @@ public class Main inherits QUnit::Test {
         ListIterator it(cases);
         while (it.next()) {
             hash a = it.getValue();
-            Process p("test_env.q", a.args, a.opts);
+            Process p(m_pfx + "test_env.q", a.args, a.opts);
             p.wait();
             int ret = p.exitCode();
 
 
-            assertEq(a.ret, ret, sprintf("env var retval for %n", a));
+            assertEq(a.ret, ret, sprintf("env var retval for %y", a));
         }
     }
 
@@ -312,10 +319,10 @@ public class Main inherits QUnit::Test {
 
     cwdTest() {
         hash opts = (
-                "cwd" : "/tmp",
+                "cwd" : realpath("/tmp"),
                 "path" : ( absolute_path("."), ),
             );
-        Process p("test_cwd.q", opts);
+        Process p(m_pfx + "test_cwd.q", opts);
         while (*string e = p.readStdout()) {
             assertEq(opts.cwd, e, "cwd value read from stdout");
         }


### PR DESCRIPTION
…100%

I think there's a problem with the return code - for example you have the following comments in the test script `process.qtest`:
```
                ( "args" : ( "PATH", get_script_dir()),
                  "opts" : ( "env" : ( "PATH" : "foo" ), ) + opts_p,
                  "ret" : 127 ), # TODO/FIXME: really 127? echo $? returns 3...
```

Also on Darwin the return code is 3 and not 127

Furthermore the following tests are failing:
```
david@quasar:~/src/qore/git/module-process/build$ ../test/process.qtest 
QUnit Test "Process" v1.0
FAILURE: Executor events test: closure: 6 assertions, 5 succeeded
Assertion "on_success error_message check" failure at ../test/process.qtest:120
-----
	>> Expected: "Success", Actual: "Undefined error: 0"
-----
FAILURE: Executor events test: refs: 5 assertions, 4 succeeded
Assertion "on_success error_message check" failure at ../test/process.qtest:412
-----
	>> Expected: "Success", Actual: "Undefined error: 0"
-----
FAILURE: Env vars test: 1 assertion, 0 succeeded
Assertion "env var retval for {args: [\"FOO\", \"bar\"], opts: {env: {FOO: \"bar\"}, path: [\"/Users/david/src/qore/git/module-process/build\"]}, ret: 0}" failure at ../test/process.qtest:297
-----
	>> Expected: 0, Actual: 127
-----
Ran 16 test cases, 13 succeeded, 3 error (49 assertions, 46 succeeded)
```

So it looks like there are some internal errors - `Undefined error: 0` looks like it's OK but somehow returned as an error; also the last error appears to indicate a possible problem with environment handling.

More work will need to be done to make this work with Windows - the tests were not written to be platform-independent.

BTW I created a `develop` branch and made it the default for this project - I hope it's OK...