### PR TITLE
feat: add getCommandLine, getPidsForPort, getPidsForUnixSocket

### DIFF
--- a/3rd_party/boost_1_90_0/libs/process/src/ext/cmd.cpp
+++ b/3rd_party/boost_1_90_0/libs/process/src/ext/cmd.cpp
@@ -175,7 +175,7 @@ shell cmd(boost::process::v2::pid_type pid, error_code & ec)
 
     std::string procargs;
     procargs.resize(argmax - 1);
-    mib[1] = KERN_PROCARGS;
+    mib[1] = KERN_PROCARGS2;
     mib[2] = pid;
 
     size = argmax;
@@ -186,27 +186,46 @@ shell cmd(boost::process::v2::pid_type pid, error_code & ec)
         return {};
     }
 
+    // KERN_PROCARGS2 format: [argc (int)][exec_path\0][padding \0s][argv[0]\0]...[argv[argc-1]\0][env...]
     int argc = *reinterpret_cast<const int*>(procargs.data());
     auto itr = procargs.begin() + sizeof(argc);
+    const auto end = procargs.begin() + size;
+
+    // Skip exec_path (null-terminated)
+    auto e = std::find(itr, end, '\0');
+    if (e == end)
+    {
+        BOOST_PROCESS_V2_ASSIGN_EC(ec, EINVAL, system_category());
+        return {};
+    }
+    itr = e + 1;
+
+    // Skip padding null bytes between exec_path and argv[0]
+    while (itr != end && *itr == '\0')
+        ++itr;
 
     std::unique_ptr<char*[]> argv{new char*[argc + 1]};
-    const auto end = procargs.end();
 
     argv[argc] = nullptr; //args is a null-terminated list
 
-    for (auto n = 0u; n <= argc; n++)
+    for (auto n = 0; n < argc; n++)
     {
-        auto e = std::find(itr, end, '\0');
-        if (e == end && n < argc) // something off
+        if (itr >= end)
         {
             BOOST_PROCESS_V2_ASSIGN_EC(ec, EINVAL, system_category());
             return {};
         }
         argv[n] = &*itr;
-        itr = e + 1; // start searching start
+        e = std::find(itr, end, '\0');
+        if (e == end && n < argc - 1) // something off
+        {
+            BOOST_PROCESS_V2_ASSIGN_EC(ec, EINVAL, system_category());
+            return {};
+        }
+        itr = e + 1; // start searching after null
     }
 
-    auto fr_func = +[](int argc, char ** argv) {delete [] argv;};
+    auto fr_func = +[](int /*argc*/, char ** argv) {delete [] argv;};
 
     return make_cmd_shell_::make(std::move(procargs), argc, argv.release(), fr_func);
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ qore_external_binary_module(
 )
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     target_link_libraries(${module_name} PRIVATE Boost::process proc)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "DragonFly"
+       OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+    target_link_libraries(${module_name} PRIVATE Boost::process kvm)
 else()
     target_link_libraries(${module_name} PRIVATE Boost::process)
 endif()

--- a/src/QC_Process.qpp
+++ b/src/QC_Process.qpp
@@ -1,7 +1,7 @@
 /*
     Qore Programming Language process Module
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -59,6 +59,32 @@
 #define HAVE_PROCESS_WAITFORTERMINATION 0
 #endif
 
+// getCommandLine: supported wherever Boost ext::cmd works
+// (Linux, macOS, FreeBSD, DragonFly, NetBSD, OpenBSD)
+#if defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)) \
+    || defined(__FreeBSD__) || defined(__DragonFly__) \
+    || defined(__NetBSD__) || defined(__OpenBSD__)
+#define HAVE_PROCESS_GETCOMMANDLINE 1
+#else
+#define HAVE_PROCESS_GETCOMMANDLINE 0
+#endif
+
+// getPidsForPort: supported on Linux, macOS, FreeBSD, DragonFly
+#if defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)) \
+    || defined(__FreeBSD__) || defined(__DragonFly__)
+#define HAVE_PROCESS_GETPIDSFORPORT 1
+#else
+#define HAVE_PROCESS_GETPIDSFORPORT 0
+#endif
+
+// getPidsForUnixSocket: supported on Linux, macOS, FreeBSD, DragonFly
+#if defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)) \
+    || defined(__FreeBSD__) || defined(__DragonFly__)
+#define HAVE_PROCESS_GETPIDSFORUNIXSOCKET 1
+#else
+#define HAVE_PROCESS_GETPIDSFORUNIXSOCKET 0
+#endif
+
 DLLLOCAL extern const TypedHashDecl* hashdeclMemorySummaryInfo;
 DLLLOCAL extern const TypedHashDecl* hashdeclProcessResult;
 DLLLOCAL extern const TypedHashDecl* hashdeclResourceUsageInfo;
@@ -85,6 +111,15 @@ const HAVE_PROCESS_WAITFORTERMINATION = bool(HAVE_PROCESS_WAITFORTERMINATION);
 
 //! Defines if @ref Qore::Process::Process::getDescriptorCount() "Process::getDescriptorCount()" is available
 const HAVE_PROCESS_GETDESCRIPTORCOUNT = bool(HAVE_PROCESS_GETDESCRIPTORCOUNT);
+
+//! Defines if @ref Qore::Process::Process::getCommandLine() "Process::getCommandLine()" is available
+const HAVE_PROCESS_GETCOMMANDLINE = bool(HAVE_PROCESS_GETCOMMANDLINE);
+
+//! Defines if @ref Qore::Process::Process::getPidsForPort() "Process::getPidsForPort()" is available
+const HAVE_PROCESS_GETPIDSFORPORT = bool(HAVE_PROCESS_GETPIDSFORPORT);
+
+//! Defines if @ref Qore::Process::Process::getPidsForUnixSocket() "Process::getPidsForUnixSocket()" is available
+const HAVE_PROCESS_GETPIDSFORUNIXSOCKET = bool(HAVE_PROCESS_GETPIDSFORUNIXSOCKET);
 ///@}
 
 //! A hash of summary memory information as provided by @ref Qore::Process::Process::getMemorySummaryInfo() "Process::getMemorySummaryInfo()"
@@ -1310,4 +1345,96 @@ static hash<ProcessResult> Process::pipeline(softlist<softlist<softstring>> comm
     QoreHashNode* result = ProcessPriv::run(shellCmd->c_str(), nullptr, *opts, 0, xsink);
     shellCmd->deref();
     return result;
+}
+
+//! Returns the command line of a process as a string
+/** @par Example:
+    @code{.py}
+string cmdline = Process::getCommandLine(getpid());
+printf("Current process: %s\n", cmdline);
+    @endcode
+
+    @param pid the PID of the process
+
+    @return the command line of the process as a string with arguments separated by spaces
+
+    @throw PROCESS-GETCOMMANDLINE-ERROR if the command line cannot be read (e.g. process does not exist
+        or insufficient permissions)
+    @throw PROCESS-GETCOMMANDLINE-UNSUPPORTED-ERROR if this method is not available on the current platform
+
+    @note
+    - Supported on Linux, macOS, FreeBSD, DragonFly, NetBSD, and OpenBSD
+    - On all platforms, returns the full command line with arguments separated by spaces
+    - On macOS, may require elevated privileges to read command lines of other users' processes
+    - On FreeBSD/DragonFly/NetBSD/OpenBSD, requires the kvm library
+
+    @see HAVE_PROCESS_GETCOMMANDLINE
+
+    @since process 2.1
+*/
+static string Process::getCommandLine(int pid) [flags=RET_VALUE_ONLY] {
+    return ProcessPriv::getCommandLine(pid, xsink);
+}
+
+//! Returns a list of PIDs that have a listening TCP socket on the given port
+/** @par Example:
+    @code{.py}
+list<int> pids = Process::getPidsForPort(8001);
+if (pids) {
+    printf("Port 8001 is used by PIDs: %y\n", pids);
+}
+    @endcode
+
+    @param port the TCP port number to check (1-65535)
+
+    @return a list of PIDs that are listening on the given port; an empty list if no process is listening
+
+    @throw PROCESS-GETPIDSFORPORT-ERROR if the port is invalid or an error occurs scanning process information
+    @throw PROCESS-GETPIDSFORPORT-UNSUPPORTED-ERROR if this method is not available on the current platform
+
+    @note
+    - On Linux, this scans /proc/net/tcp and /proc/net/tcp6 for listening sockets and matches
+      socket inodes to PIDs via /proc/PID/fd; this works on all Linux variants including Alpine (busybox)
+    - On macOS, this uses native libproc APIs to enumerate process file descriptors and filter for TCP
+      listening sockets; only LISTEN-state sockets are matched
+    - On FreeBSD/DragonFly, this uses sysctl KERN_PROC_FILEDESC to enumerate file descriptors
+    - May require elevated privileges to see sockets of other users' processes
+
+    @see HAVE_PROCESS_GETPIDSFORPORT
+
+    @since process 2.1
+*/
+static list<int> Process::getPidsForPort(int port) [flags=RET_VALUE_ONLY] {
+    return ProcessPriv::getPidsForPort(port, xsink);
+}
+
+//! Returns a list of PIDs that have the given Unix domain socket path open
+/** @par Example:
+    @code{.py}
+list<int> pids = Process::getPidsForUnixSocket("/var/run/app.sock");
+if (pids) {
+    printf("Socket is used by PIDs: %y\n", pids);
+}
+    @endcode
+
+    @param path the Unix domain socket path to check
+
+    @return a list of PIDs that have the given Unix domain socket open; an empty list if no process has it open
+
+    @throw PROCESS-GETPIDSFORUNIXSOCKET-ERROR if the path is empty or an error occurs scanning process information
+    @throw PROCESS-GETPIDSFORUNIXSOCKET-UNSUPPORTED-ERROR if this method is not available on the current platform
+
+    @note
+    - On Linux, this parses /proc/net/unix to find socket inodes matching the path, then scans /proc/PID/fd
+      for matching socket symlinks
+    - On macOS, this uses native libproc APIs to enumerate process file descriptors and match Unix socket paths
+    - On FreeBSD/DragonFly, this uses sysctl KERN_PROC_FILEDESC to enumerate file descriptors
+    - May require elevated privileges to see sockets of other users' processes
+
+    @see HAVE_PROCESS_GETPIDSFORUNIXSOCKET
+
+    @since process 2.1
+*/
+static list<int> Process::getPidsForUnixSocket(string path) [flags=RET_VALUE_ONLY] {
+    return ProcessPriv::getPidsForUnixSocket(path->c_str(), xsink);
 }

--- a/src/process.qpp
+++ b/src/process.qpp
@@ -1,7 +1,7 @@
 /*
     Qore Programming Language process Module
 
-    Copyright (C) 2003 - 2025 Qore Technologies, s.r.o.
+    Copyright (C) 2003 - 2026 Qore Technologies, s.r.o.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -55,6 +55,9 @@ The %process module provides an API to manage system processes. It can be used t
     - File descriptor counting via \c /proc/PID/fd
     - Signal sending via kill()
     - All executor callbacks
+    - @ref Qore::Process::Process::getCommandLine() "Process::getCommandLine()" via \c /proc/PID/cmdline
+    - @ref Qore::Process::Process::getPidsForPort() "Process::getPidsForPort()" via \c /proc/net/tcp + \c /proc/PID/fd
+    - @ref Qore::Process::Process::getPidsForUnixSocket() "Process::getPidsForUnixSocket()" via \c /proc/net/unix + \c /proc/PID/fd
 
     @subsection process_platforms_macos macOS / Darwin
     Full support with some limitations:
@@ -65,6 +68,24 @@ The %process module provides an API to manage system processes. It can be used t
         the \c "com.apple.system-task-ports" entitlement
     - File descriptor counting: fully supported via \c libproc
     - Signal sending: fully supported
+    - @ref Qore::Process::Process::getCommandLine() "Process::getCommandLine()" via \c KERN_PROCARGS sysctl (returns full command line with arguments)
+    - @ref Qore::Process::Process::getPidsForPort() "Process::getPidsForPort()" via native \c libproc APIs (only LISTEN-state TCP sockets)
+    - @ref Qore::Process::Process::getPidsForUnixSocket() "Process::getPidsForUnixSocket()" via native \c libproc APIs
+    - @note May require elevated privileges to see other users' processes
+
+    @subsection process_platforms_bsd FreeBSD / DragonFly BSD
+    Good support:
+    - Process creation and management: fully supported
+    - @ref Qore::Process::Process::getCommandLine() "Process::getCommandLine()" via kvm library
+    - @ref Qore::Process::Process::getPidsForPort() "Process::getPidsForPort()" via \c sysctl \c KERN_PROC_FILEDESC
+    - @ref Qore::Process::Process::getPidsForUnixSocket() "Process::getPidsForUnixSocket()" via \c sysctl \c KERN_PROC_FILEDESC
+
+    @subsection process_platforms_netbsd_openbsd NetBSD / OpenBSD
+    Partial support:
+    - Process creation and management: fully supported
+    - @ref Qore::Process::Process::getCommandLine() "Process::getCommandLine()" via kvm library
+    - @ref Qore::Process::Process::getPidsForPort() "Process::getPidsForPort()" NOT supported
+    - @ref Qore::Process::Process::getPidsForUnixSocket() "Process::getPidsForUnixSocket()" NOT supported
 
     @subsection process_platforms_solaris Solaris
     Partial support:
@@ -91,6 +112,14 @@ Version 1.0. (See http://www.boost.org/LICENSE_1_0.txt)
     @subsection process_v2_1 process v2.1
 
     <b>New Features:</b>
+    - added @ref Qore::Process::Process::getCommandLine() "Process::getCommandLine()" to get the full command
+      line of a process by PID using Boost ext::cmd; supported on Linux, macOS, FreeBSD, DragonFly, NetBSD,
+      and OpenBSD
+    - added @ref Qore::Process::Process::getPidsForPort() "Process::getPidsForPort()" to find PIDs listening
+      on a TCP port; uses \c /proc/net/tcp on Linux, native \c libproc APIs on macOS, and \c sysctl
+      \c KERN_PROC_FILEDESC on FreeBSD and DragonFly BSD; only matches TCP sockets in LISTEN state
+    - added @ref Qore::Process::Process::getPidsForUnixSocket() "Process::getPidsForUnixSocket()" to find PIDs
+      using a Unix domain socket; supported on Linux, macOS, FreeBSD, and DragonFly BSD
     - added @ref Qore::Process::Process::closeStdin() "Process::closeStdin()" to signal EOF to child processes
     - added @ref Qore::Process::Process::sendSignal() "Process::sendSignal()" for graceful termination via specific signals
     - added @ref Qore::Process::Process::run() "Process::run()" convenience method to run a command and capture output

--- a/src/processpriv.cpp
+++ b/src/processpriv.cpp
@@ -26,14 +26,17 @@
 
 #include <unistd.h>
 #include <dirent.h>
+#include <sched.h>
 
 // std
+#include <chrono>
 #include <exception>
 #include <cctype>
 #include <stdexcept>
 
 // boost
 #include <boost/numeric/conversion/cast.hpp>
+#include <boost/process/v2/ext/cmd.hpp>
 
 // module
 #include "unix-config.h"
@@ -2545,6 +2548,765 @@ bool ProcessPriv::terminateTree(ExceptionSink* xsink) {
     // Just terminate the main process for now; this is equivalent to terminate()
     return terminate(xsink);
 }
+
+QoreStringNode* ProcessPriv::getCommandLine(int pid, ExceptionSink* xsink) {
+    if (pid <= 0) {
+        xsink->raiseException("PROCESS-GETCOMMANDLINE-ERROR", "PID must be positive (got %d)", pid);
+        return nullptr;
+    }
+
+    // Retry on empty result: when a process is launched via a shebang script (e.g. #!/usr/bin/env qore),
+    // the kernel performs two exec() calls.  The CLOEXEC pipe (boost::process startup sync) closes on the
+    // first exec, but /proc/PID/cmdline is transiently empty during the second exec.  The empty window
+    // lasts for the kernel's execve() processing time (typically <1ms, but potentially longer under heavy
+    // load or with cold caches).  We use a wall-clock-bounded retry with exponential backoff to handle
+    // this reliably regardless of CPU speed or system load.
+    constexpr int64_t timeout_us = 5'000'000;  // 5 second total timeout
+    constexpr int yield_attempts = 10;          // initial fast sched_yield attempts
+    constexpr int64_t initial_sleep_us = 1000;  // 1ms initial sleep after yields
+    constexpr int64_t max_sleep_us = 100'000;   // 100ms max sleep interval
+
+    auto start = std::chrono::steady_clock::now();
+    int attempt = 0;
+
+    while (true) {
+        boost::system::error_code ec;
+        auto sh = boost::process::v2::ext::cmd(pid, ec);
+        if (ec) {
+            if (ec.value() == ENOTSUP) {
+                xsink->raiseException("PROCESS-GETCOMMANDLINE-UNSUPPORTED-ERROR",
+                    "getCommandLine() is not supported on this platform");
+            } else {
+                xsink->raiseException("PROCESS-GETCOMMANDLINE-ERROR",
+                    "cannot get command line for PID %d: %s", pid, ec.message().c_str());
+            }
+            return nullptr;
+        }
+
+        if (!sh.empty()) {
+            SimpleRefHolder<QoreStringNode> rv(new QoreStringNode(sh.argv()[0]));
+            for (int i = 1; i < sh.argc(); ++i) {
+                rv->concat(' ');
+                rv->concat(sh.argv()[i]);
+            }
+            return rv.release();
+        }
+
+        // Empty result - check timeout
+        auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - start).count();
+        if (elapsed >= timeout_us) {
+            xsink->raiseException("PROCESS-GETCOMMANDLINE-ERROR",
+                "empty command line for PID %d (timed out after %g seconds)", pid,
+                static_cast<double>(elapsed) / 1'000'000.0);
+            return nullptr;
+        }
+
+        // Check if the process still exists before retrying
+        if (kill(pid, 0) != 0) {
+            xsink->raiseException("PROCESS-GETCOMMANDLINE-ERROR",
+                "cannot get command line for PID %d: process no longer exists", pid);
+            return nullptr;
+        }
+
+        if (attempt < yield_attempts) {
+            // Fast path: sched_yield() for the common case where exec completes in microseconds
+            sched_yield();
+        } else {
+            // Exponential backoff: 1ms, 2ms, 4ms, ..., capped at 100ms
+            int64_t sleep_us = std::min(initial_sleep_us << (attempt - yield_attempts), max_sleep_us);
+            int64_t remaining_us = timeout_us - elapsed;
+            sleep_us = std::min(sleep_us, remaining_us);
+            struct timespec ts = {0, sleep_us * 1000};
+            nanosleep(&ts, nullptr);
+        }
+        ++attempt;
+    }
+}
+
+#if defined(__linux__)
+QoreListNode* ProcessPriv::getPidsForPort(int port, ExceptionSink* xsink) {
+    if (port <= 0 || port > 65535) {
+        xsink->raiseException("PROCESS-GETPIDSFORPORT-ERROR",
+            "port must be between 1 and 65535 (got %d)", port);
+        return nullptr;
+    }
+
+    char hex_port[16];
+    snprintf(hex_port, sizeof(hex_port), "%04X", port);
+
+    // Collect socket inodes for LISTEN sockets on this port from /proc/net/tcp and tcp6
+    std::unordered_map<std::string, bool> target_inodes;
+
+    const char* tcp_files[] = {"/proc/net/tcp", "/proc/net/tcp6"};
+    for (const char* tcp_file : tcp_files) {
+        QoreFile f;
+        if (f.open(tcp_file)) {
+            continue;
+        }
+
+        QoreStringNodeHolder content(f.read(-1, -1, xsink));
+        if (*xsink) {
+            xsink->clear();
+            continue;
+        }
+        if (!content || !content->size()) {
+            continue;
+        }
+
+        // Parse each line
+        const char* p = content->c_str();
+        while (*p) {
+            // Find end of line
+            const char* eol = strchr(p, '\n');
+            if (!eol) {
+                eol = p + strlen(p);
+            }
+
+            // Skip header line
+            const char* line = p;
+            p = (*eol) ? eol + 1 : eol;
+
+            // Skip leading whitespace
+            while (line < eol && (*line == ' ' || *line == '\t')) {
+                ++line;
+            }
+            // Skip header
+            if (line < eol && (*line == 's' || *line == 'S')) {
+                continue;
+            }
+
+            // Parse fields: we need field[1] (local_address), field[3] (state), field[9] (inode)
+            // Fields are whitespace-separated
+            const char* fields[12];
+            int nfields = 0;
+            const char* fp = line;
+            while (fp < eol && nfields < 12) {
+                // Skip whitespace
+                while (fp < eol && (*fp == ' ' || *fp == '\t')) {
+                    ++fp;
+                }
+                if (fp >= eol) {
+                    break;
+                }
+                fields[nfields++] = fp;
+                // Skip non-whitespace
+                while (fp < eol && *fp != ' ' && *fp != '\t') {
+                    ++fp;
+                }
+            }
+
+            if (nfields < 10) {
+                continue;
+            }
+
+            // Check state == "0A" (LISTEN)
+            if (fields[3][0] != '0' || (fields[3][1] != 'A' && fields[3][1] != 'a')) {
+                continue;
+            }
+
+            // Check local_address ends with :HEXPORT
+            // local_address format: HEXIP:HEXPORT
+            const char* colon = nullptr;
+            {
+                const char* fp2 = fields[1];
+                while (fp2 < fields[2] && *fp2 != ' ' && *fp2 != '\t') {
+                    if (*fp2 == ':') {
+                        colon = fp2;
+                    }
+                    ++fp2;
+                }
+            }
+            if (!colon) {
+                continue;
+            }
+            // Compare hex port (case-insensitive)
+            if (strncasecmp(colon + 1, hex_port, 4) != 0) {
+                continue;
+            }
+
+            // Get inode (field 9)
+            std::string inode(fields[9]);
+            // Trim to just the field
+            {
+                size_t end = inode.find_first_of(" \t\n");
+                if (end != std::string::npos) {
+                    inode.erase(end);
+                }
+            }
+            if (inode != "0") {
+                target_inodes[inode] = true;
+            }
+        }
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(bigIntTypeInfo), xsink);
+
+    if (target_inodes.empty()) {
+        return rv.release();
+    }
+
+    // Scan /proc/<pid>/fd to find PIDs with matching socket inodes
+    DIR* procdir = opendir("/proc");
+    if (!procdir) {
+        xsink->raiseErrnoException("PROCESS-GETPIDSFORPORT-ERROR", errno, "cannot open /proc");
+        return nullptr;
+    }
+
+    std::unordered_map<int, bool> found_pids;
+    struct dirent* entry;
+    while ((entry = readdir(procdir)) != nullptr) {
+        // Check if entry is a PID directory
+        char* endptr;
+        long pid_val = strtol(entry->d_name, &endptr, 10);
+        if (*endptr != '\0' || pid_val <= 0) {
+            continue;
+        }
+
+        QoreStringMaker fd_path("/proc/%ld/fd", pid_val);
+        DIR* fddir = opendir(fd_path.c_str());
+        if (!fddir) {
+            continue;
+        }
+
+        struct dirent* fd_entry;
+        bool found = false;
+        while ((fd_entry = readdir(fddir)) != nullptr) {
+            QoreStringMaker link_path("%s/%s", fd_path.c_str(), fd_entry->d_name);
+            char target[256];
+            ssize_t len = readlink(link_path.c_str(), target, sizeof(target) - 1);
+            if (len <= 0) {
+                continue;
+            }
+            target[len] = '\0';
+
+            // Check for "socket:[INODE]"
+            if (strncmp(target, "socket:[", 8) != 0) {
+                continue;
+            }
+            // Extract inode number
+            char* inode_start = target + 8;
+            char* inode_end = strchr(inode_start, ']');
+            if (!inode_end) {
+                continue;
+            }
+            std::string inode(inode_start, inode_end - inode_start);
+            if (target_inodes.count(inode)) {
+                found = true;
+                break;
+            }
+        }
+        closedir(fddir);
+
+        if (found) {
+            found_pids[(int)pid_val] = true;
+        }
+    }
+    closedir(procdir);
+
+    for (const auto& kv : found_pids) {
+        rv->push((int64)kv.first, xsink);
+    }
+
+    return rv.release();
+}
+#elif defined(__APPLE__) && defined(__MACH__)
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <arpa/inet.h>
+#include <sys/proc_info.h>
+
+QoreListNode* ProcessPriv::getPidsForPort(int port, ExceptionSink* xsink) {
+    if (port <= 0 || port > 65535) {
+        xsink->raiseException("PROCESS-GETPIDSFORPORT-ERROR",
+            "port must be between 1 and 65535 (got %d)", port);
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(bigIntTypeInfo), xsink);
+
+    // Get list of all PIDs
+    int numPids = proc_listpids(PROC_ALL_PIDS, 0, nullptr, 0);
+    if (numPids <= 0) {
+        return rv.release();
+    }
+
+    std::vector<pid_t> pids(numPids);
+    numPids = proc_listpids(PROC_ALL_PIDS, 0, pids.data(), numPids * sizeof(pid_t));
+    numPids /= sizeof(pid_t);
+
+    std::unordered_map<int, bool> found_pids;
+
+    for (int i = 0; i < numPids; i++) {
+        if (pids[i] == 0) {
+            continue;
+        }
+
+        // Get file descriptor list for this PID
+        int bufsize = proc_pidinfo(pids[i], PROC_PIDLISTFDS, 0, nullptr, 0);
+        if (bufsize <= 0) {
+            continue;
+        }
+
+        std::vector<char> buf(bufsize);
+        int actual = proc_pidinfo(pids[i], PROC_PIDLISTFDS, 0, buf.data(), bufsize);
+        if (actual <= 0) {
+            continue;
+        }
+
+        int numFds = actual / sizeof(struct proc_fdinfo);
+        struct proc_fdinfo* fdinfo = reinterpret_cast<struct proc_fdinfo*>(buf.data());
+
+        for (int j = 0; j < numFds; j++) {
+            if (fdinfo[j].proc_fdtype != PROX_FDTYPE_SOCKET) {
+                continue;
+            }
+
+            struct socket_fdinfo si;
+            int siSize = proc_pidfdinfo(pids[i], fdinfo[j].proc_fd,
+                PROC_PIDFDSOCKETINFO, &si, sizeof(si));
+            if (siSize != sizeof(si)) {
+                continue;
+            }
+
+            // Check for TCP socket in LISTEN state on the target port
+            if ((si.psi.soi_family == AF_INET || si.psi.soi_family == AF_INET6)
+                && si.psi.soi_kind == SOCKINFO_TCP
+                && si.psi.soi_proto.pri_tcp.tcpsi_state == TSI_S_LISTEN
+                && ntohs(si.psi.soi_proto.pri_tcp.tcpsi_ini.insi_lport) == port) {
+                if (!found_pids.count(pids[i])) {
+                    found_pids[pids[i]] = true;
+                }
+                break;
+            }
+        }
+    }
+
+    for (const auto& kv : found_pids) {
+        rv->push((int64)kv.first, xsink);
+    }
+
+    return rv.release();
+}
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/user.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+QoreListNode* ProcessPriv::getPidsForPort(int port, ExceptionSink* xsink) {
+    if (port <= 0 || port > 65535) {
+        xsink->raiseException("PROCESS-GETPIDSFORPORT-ERROR",
+            "port must be between 1 and 65535 (got %d)", port);
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(bigIntTypeInfo), xsink);
+
+    // Get list of all processes
+    int mib_procs[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0};
+    size_t procs_len = 0;
+    if (sysctl(mib_procs, 3, nullptr, &procs_len, nullptr, 0) < 0) {
+        return rv.release();
+    }
+
+    std::vector<char> procs_buf(procs_len);
+    if (sysctl(mib_procs, 3, procs_buf.data(), &procs_len, nullptr, 0) < 0) {
+        return rv.release();
+    }
+
+    int num_procs = procs_len / sizeof(struct kinfo_proc);
+    struct kinfo_proc* procs = reinterpret_cast<struct kinfo_proc*>(procs_buf.data());
+
+    std::unordered_map<int, bool> found_pids;
+
+    for (int i = 0; i < num_procs; i++) {
+        pid_t pid = procs[i].ki_pid;
+        if (pid <= 0) {
+            continue;
+        }
+
+        // Get file descriptors for this PID
+        int mib_fd[4] = {CTL_KERN, KERN_PROC, KERN_PROC_FILEDESC, pid};
+        size_t fd_len = 0;
+        if (sysctl(mib_fd, 4, nullptr, &fd_len, nullptr, 0) < 0) {
+            continue;
+        }
+
+        std::vector<char> fd_buf(fd_len);
+        if (sysctl(mib_fd, 4, fd_buf.data(), &fd_len, nullptr, 0) < 0) {
+            continue;
+        }
+
+        // Iterate over kinfo_file entries (variable-length)
+        char* p = fd_buf.data();
+        char* end = p + fd_len;
+        while (p < end) {
+            struct kinfo_file* kf = reinterpret_cast<struct kinfo_file*>(p);
+            if (kf->kf_structsize == 0) {
+                break;
+            }
+
+            if (kf->kf_type == KF_TYPE_SOCKET
+                && (kf->kf_sock_domain == AF_INET || kf->kf_sock_domain == AF_INET6)
+                && kf->kf_sock_type == SOCK_STREAM) {
+                // Check for LISTEN state
+                // On FreeBSD, kf_sock_protocol == IPPROTO_TCP and kf_un.kf_sock.kf_sock_sendq == 0
+                // for listening sockets; check local port via kf_sa_local
+                struct sockaddr* sa = reinterpret_cast<struct sockaddr*>(&kf->kf_sa_local);
+                int local_port = 0;
+                if (sa->sa_family == AF_INET) {
+                    local_port = ntohs(reinterpret_cast<struct sockaddr_in*>(sa)->sin_port);
+                } else if (sa->sa_family == AF_INET6) {
+                    local_port = ntohs(reinterpret_cast<struct sockaddr_in6*>(sa)->sin6_port);
+                }
+
+                if (local_port == port) {
+                    // Verify this is a listening socket by checking the peer port is 0
+                    struct sockaddr* peer = reinterpret_cast<struct sockaddr*>(&kf->kf_sa_peer);
+                    int peer_port = -1;
+                    if (peer->sa_family == AF_INET) {
+                        peer_port = ntohs(reinterpret_cast<struct sockaddr_in*>(peer)->sin_port);
+                    } else if (peer->sa_family == AF_INET6) {
+                        peer_port = ntohs(reinterpret_cast<struct sockaddr_in6*>(peer)->sin6_port);
+                    }
+
+                    if (peer_port == 0 && !found_pids.count(pid)) {
+                        found_pids[pid] = true;
+                    }
+                }
+            }
+
+            p += kf->kf_structsize;
+        }
+    }
+
+    for (const auto& kv : found_pids) {
+        rv->push((int64)kv.first, xsink);
+    }
+
+    return rv.release();
+}
+#else
+QoreListNode* ProcessPriv::getPidsForPort(int port, ExceptionSink* xsink) {
+    xsink->raiseException("PROCESS-GETPIDSFORPORT-UNSUPPORTED-ERROR",
+        "getPidsForPort() is not supported on this platform");
+    return nullptr;
+}
+#endif
+
+#if defined(__linux__)
+QoreListNode* ProcessPriv::getPidsForUnixSocket(const char* path, ExceptionSink* xsink) {
+    if (!path || !*path) {
+        xsink->raiseException("PROCESS-GETPIDSFORUNIXSOCKET-ERROR", "socket path must not be empty");
+        return nullptr;
+    }
+
+    // Parse /proc/net/unix to find inode(s) for the target socket path
+    std::unordered_map<std::string, bool> target_inodes;
+
+    {
+        QoreFile f;
+        if (f.open("/proc/net/unix")) {
+            // If we can't open /proc/net/unix, return empty list
+            return new QoreListNode(bigIntTypeInfo);
+        }
+
+        QoreStringNodeHolder content(f.read(-1, -1, xsink));
+        if (*xsink) {
+            return nullptr;
+        }
+        if (!content || !content->size()) {
+            return new QoreListNode(bigIntTypeInfo);
+        }
+
+        // Format: Num RefCount Protocol Flags Type St Inode Path
+        const char* p = content->c_str();
+        while (*p) {
+            const char* eol = strchr(p, '\n');
+            if (!eol) {
+                eol = p + strlen(p);
+            }
+
+            const char* line = p;
+            p = (*eol) ? eol + 1 : eol;
+
+            // Skip leading whitespace
+            while (line < eol && (*line == ' ' || *line == '\t')) {
+                ++line;
+            }
+            // Skip header line
+            if (line < eol && (*line == 'N' || *line == 'n')) {
+                continue;
+            }
+
+            // Parse fields: we need field[6] (inode) and field[7] (path)
+            const char* fields[8] = {};
+            int nfields = 0;
+            const char* fp = line;
+            while (fp < eol && nfields < 8) {
+                while (fp < eol && (*fp == ' ' || *fp == '\t')) {
+                    ++fp;
+                }
+                if (fp >= eol) {
+                    break;
+                }
+                fields[nfields++] = fp;
+                while (fp < eol && *fp != ' ' && *fp != '\t') {
+                    ++fp;
+                }
+            }
+
+            // Need at least 8 fields (with path)
+            if (nfields < 8) {
+                continue;
+            }
+
+            // Extract path field (field[7] to end of line)
+            std::string sock_path(fields[7], eol - fields[7]);
+            // Trim trailing whitespace
+            while (!sock_path.empty() && (sock_path.back() == ' ' || sock_path.back() == '\t'
+                    || sock_path.back() == '\n')) {
+                sock_path.pop_back();
+            }
+
+            if (sock_path == path) {
+                // Extract inode (field[6])
+                std::string inode(fields[6]);
+                size_t end = inode.find_first_of(" \t\n");
+                if (end != std::string::npos) {
+                    inode.erase(end);
+                }
+                if (inode != "0") {
+                    target_inodes[inode] = true;
+                }
+            }
+        }
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(bigIntTypeInfo), xsink);
+
+    if (target_inodes.empty()) {
+        return rv.release();
+    }
+
+    // Scan /proc/<pid>/fd to find PIDs with matching socket inodes
+    DIR* procdir = opendir("/proc");
+    if (!procdir) {
+        xsink->raiseErrnoException("PROCESS-GETPIDSFORUNIXSOCKET-ERROR", errno, "cannot open /proc");
+        return nullptr;
+    }
+
+    std::unordered_map<int, bool> found_pids;
+    struct dirent* entry;
+    while ((entry = readdir(procdir)) != nullptr) {
+        char* endptr;
+        long pid_val = strtol(entry->d_name, &endptr, 10);
+        if (*endptr != '\0' || pid_val <= 0) {
+            continue;
+        }
+
+        QoreStringMaker fd_path("/proc/%ld/fd", pid_val);
+        DIR* fddir = opendir(fd_path.c_str());
+        if (!fddir) {
+            continue;
+        }
+
+        struct dirent* fd_entry;
+        bool found = false;
+        while ((fd_entry = readdir(fddir)) != nullptr) {
+            QoreStringMaker link_path("%s/%s", fd_path.c_str(), fd_entry->d_name);
+            char target[256];
+            ssize_t len = readlink(link_path.c_str(), target, sizeof(target) - 1);
+            if (len <= 0) {
+                continue;
+            }
+            target[len] = '\0';
+
+            // Check for "socket:[INODE]"
+            if (strncmp(target, "socket:[", 8) != 0) {
+                continue;
+            }
+            char* inode_start = target + 8;
+            char* inode_end = strchr(inode_start, ']');
+            if (!inode_end) {
+                continue;
+            }
+            std::string inode(inode_start, inode_end - inode_start);
+            if (target_inodes.count(inode)) {
+                found = true;
+                break;
+            }
+        }
+        closedir(fddir);
+
+        if (found) {
+            found_pids[(int)pid_val] = true;
+        }
+    }
+    closedir(procdir);
+
+    for (const auto& kv : found_pids) {
+        rv->push((int64)kv.first, xsink);
+    }
+
+    return rv.release();
+}
+#elif defined(__APPLE__) && defined(__MACH__)
+QoreListNode* ProcessPriv::getPidsForUnixSocket(const char* path, ExceptionSink* xsink) {
+    if (!path || !*path) {
+        xsink->raiseException("PROCESS-GETPIDSFORUNIXSOCKET-ERROR", "socket path must not be empty");
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(bigIntTypeInfo), xsink);
+
+    // Get list of all PIDs
+    int numPids = proc_listpids(PROC_ALL_PIDS, 0, nullptr, 0);
+    if (numPids <= 0) {
+        return rv.release();
+    }
+
+    std::vector<pid_t> pids(numPids);
+    numPids = proc_listpids(PROC_ALL_PIDS, 0, pids.data(), numPids * sizeof(pid_t));
+    numPids /= sizeof(pid_t);
+
+    std::unordered_map<int, bool> found_pids;
+
+    for (int i = 0; i < numPids; i++) {
+        if (pids[i] == 0) {
+            continue;
+        }
+
+        // Get file descriptor list for this PID
+        int bufsize = proc_pidinfo(pids[i], PROC_PIDLISTFDS, 0, nullptr, 0);
+        if (bufsize <= 0) {
+            continue;
+        }
+
+        std::vector<char> buf(bufsize);
+        int actual = proc_pidinfo(pids[i], PROC_PIDLISTFDS, 0, buf.data(), bufsize);
+        if (actual <= 0) {
+            continue;
+        }
+
+        int numFds = actual / sizeof(struct proc_fdinfo);
+        struct proc_fdinfo* fdinfo = reinterpret_cast<struct proc_fdinfo*>(buf.data());
+
+        for (int j = 0; j < numFds; j++) {
+            if (fdinfo[j].proc_fdtype != PROX_FDTYPE_SOCKET) {
+                continue;
+            }
+
+            struct socket_fdinfo si;
+            int siSize = proc_pidfdinfo(pids[i], fdinfo[j].proc_fd,
+                PROC_PIDFDSOCKETINFO, &si, sizeof(si));
+            if (siSize != sizeof(si)) {
+                continue;
+            }
+
+            // Check for Unix domain socket matching the target path
+            if (si.psi.soi_family == AF_UNIX && si.psi.soi_kind == SOCKINFO_UN) {
+                const char* sock_path = si.psi.soi_proto.pri_un.unsi_addr.ua_sun.sun_path;
+                if (sock_path[0] != '\0' && strcmp(sock_path, path) == 0) {
+                    if (!found_pids.count(pids[i])) {
+                        found_pids[pids[i]] = true;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    for (const auto& kv : found_pids) {
+        rv->push((int64)kv.first, xsink);
+    }
+
+    return rv.release();
+}
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+QoreListNode* ProcessPriv::getPidsForUnixSocket(const char* path, ExceptionSink* xsink) {
+    if (!path || !*path) {
+        xsink->raiseException("PROCESS-GETPIDSFORUNIXSOCKET-ERROR", "socket path must not be empty");
+        return nullptr;
+    }
+
+    ReferenceHolder<QoreListNode> rv(new QoreListNode(bigIntTypeInfo), xsink);
+
+    // Get list of all processes
+    int mib_procs[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PROC, 0};
+    size_t procs_len = 0;
+    if (sysctl(mib_procs, 3, nullptr, &procs_len, nullptr, 0) < 0) {
+        return rv.release();
+    }
+
+    std::vector<char> procs_buf(procs_len);
+    if (sysctl(mib_procs, 3, procs_buf.data(), &procs_len, nullptr, 0) < 0) {
+        return rv.release();
+    }
+
+    int num_procs = procs_len / sizeof(struct kinfo_proc);
+    struct kinfo_proc* procs = reinterpret_cast<struct kinfo_proc*>(procs_buf.data());
+
+    std::unordered_map<int, bool> found_pids;
+
+    for (int i = 0; i < num_procs; i++) {
+        pid_t pid = procs[i].ki_pid;
+        if (pid <= 0) {
+            continue;
+        }
+
+        // Get file descriptors for this PID
+        int mib_fd[4] = {CTL_KERN, KERN_PROC, KERN_PROC_FILEDESC, pid};
+        size_t fd_len = 0;
+        if (sysctl(mib_fd, 4, nullptr, &fd_len, nullptr, 0) < 0) {
+            continue;
+        }
+
+        std::vector<char> fd_buf(fd_len);
+        if (sysctl(mib_fd, 4, fd_buf.data(), &fd_len, nullptr, 0) < 0) {
+            continue;
+        }
+
+        char* p = fd_buf.data();
+        char* end = p + fd_len;
+        while (p < end) {
+            struct kinfo_file* kf = reinterpret_cast<struct kinfo_file*>(p);
+            if (kf->kf_structsize == 0) {
+                break;
+            }
+
+            if (kf->kf_type == KF_TYPE_SOCKET
+                && kf->kf_sock_domain == AF_UNIX) {
+                // Check socket path via kf_path
+                if (kf->kf_path[0] != '\0' && strcmp(kf->kf_path, path) == 0) {
+                    if (!found_pids.count(pid)) {
+                        found_pids[pid] = true;
+                    }
+                    break;
+                }
+            }
+
+            p += kf->kf_structsize;
+        }
+    }
+
+    for (const auto& kv : found_pids) {
+        rv->push((int64)kv.first, xsink);
+    }
+
+    return rv.release();
+}
+#else
+QoreListNode* ProcessPriv::getPidsForUnixSocket(const char* path, ExceptionSink* xsink) {
+    xsink->raiseException("PROCESS-GETPIDSFORUNIXSOCKET-UNSUPPORTED-ERROR",
+        "getPidsForUnixSocket() is not supported on this platform");
+    return nullptr;
+}
+#endif
 
 QoreHashNode* ProcessPriv::run(const char* command, const QoreListNode* arguments,
         const QoreHashNode* opts, int64 timeout_ms, ExceptionSink* xsink) {

--- a/src/processpriv.cpp
+++ b/src/processpriv.cpp
@@ -2614,10 +2614,13 @@ QoreStringNode* ProcessPriv::getCommandLine(int pid, ExceptionSink* xsink) {
             sched_yield();
         } else {
             // Exponential backoff: 1ms, 2ms, 4ms, ..., capped at 100ms
-            int64_t sleep_us = std::min(initial_sleep_us << (attempt - yield_attempts), max_sleep_us);
+            int shift = std::min(attempt - yield_attempts, 20);  // cap shift to prevent UB
+            int64_t sleep_us = std::min(initial_sleep_us << shift, max_sleep_us);
             int64_t remaining_us = timeout_us - elapsed;
             sleep_us = std::min(sleep_us, remaining_us);
-            struct timespec ts = {0, sleep_us * 1000};
+            time_t sec = static_cast<time_t>(sleep_us / 1'000'000);
+            long nsec = static_cast<long>((sleep_us % 1'000'000) * 1000);
+            struct timespec ts = {sec, nsec};
             nanosleep(&ts, nullptr);
         }
         ++attempt;

--- a/src/processpriv.h
+++ b/src/processpriv.h
@@ -146,6 +146,15 @@ public:
     //! Get child PIDs for a specific PID (static)
     DLLLOCAL static QoreListNode* getChildPids(int pid, ExceptionSink* xsink);
 
+    //! Get command line for a specific PID (static)
+    DLLLOCAL static QoreStringNode* getCommandLine(int pid, ExceptionSink* xsink);
+
+    //! Get PIDs listening on a TCP port (static)
+    DLLLOCAL static QoreListNode* getPidsForPort(int port, ExceptionSink* xsink);
+
+    //! Get PIDs using a Unix domain socket (static)
+    DLLLOCAL static QoreListNode* getPidsForUnixSocket(const char* path, ExceptionSink* xsink);
+
     //! Terminate the process and all its children
     DLLLOCAL bool terminateTree(ExceptionSink* xsink);
 

--- a/test/process.qtest
+++ b/test/process.qtest
@@ -1139,22 +1139,16 @@ public class Main inherits QUnit::Test {
         hash<auto> opts = {"path": (m_prefix,)};
         Process p("test_io.q", opts);
 
+        # test_io.q protocol: readLine (line 1), readLine (line 2), sleep 2s, readLine (exit code)
         binary data = <00010203040500060708>;  # Binary with NUL in middle
         p.write(data);
-        p.write("\n");
+        p.write("\n");       # first line: binary data with NUL
+        p.write("test\n");   # second line expected by test_io.q
+        p.write("0\n");      # third line: exit code
 
-        # Read back - note: the test_io.q reads a line, so NUL will terminate
-        # This tests that write(binary) handles NUL correctly
-        sleep(500ms);
-        p.readStdoutBinary(100);
-        # The actual behavior depends on how the child process handles binary
-        # Just verify it doesn't crash
-        assertGe(0, p.id(), "Binary with NUL should not crash");
-
-        p.write("0\n");
-        if (!p.wait(10s)) {
-            p.terminate();
-        }
+        # Wait for child to exit (test_io.q has a 2s internal sleep)
+        assertTrue(p.wait(15s), "Binary with NUL should not hang");
+        assertEq(0, p.exitCode(), "Binary with NUL should not crash");
     }
 
     runTest() {

--- a/test/process.qtest
+++ b/test/process.qtest
@@ -119,6 +119,9 @@ public class Main inherits QUnit::Test {
         addTestCase("Terminate tree test", \terminateTreeTest());
         addTestCase("Pipeline test", \pipelineTest());
         addTestCase("Resource limits test", \resourceLimitsTest());
+        addTestCase("getCommandLine test", \getCommandLineTest());
+        addTestCase("getPidsForPort test", \getPidsForPortTest());
+        addTestCase("getPidsForUnixSocket test", \getPidsForUnixSocketTest());
 
         # Return for compatibility with test harness that checks return value.
         set_return_value(main());
@@ -319,9 +322,9 @@ public class Main inherits QUnit::Test {
         string b1;
         # sleep to make sure that there is some stdout data ready
         while (True) {
-            *string str = p.readStdout(1);
-            if (str) {
-                b1 = str;
+            *string rd = p.readStdout(1);
+            if (rd) {
+                b1 = rd;
                 break;
             }
             usleep(50ms);
@@ -378,9 +381,9 @@ public class Main inherits QUnit::Test {
         p = new Process("test_utf8.q", opts);
         # read 1 byte of stdout
         while (True) {
-            *string str = p.readStdout(1);
-            if (str) {
-                b1 = str;
+            *string rd = p.readStdout(1);
+            if (rd) {
+                b1 = rd;
                 break;
             }
             usleep(50ms);
@@ -1143,10 +1146,10 @@ public class Main inherits QUnit::Test {
         # Read back - note: the test_io.q reads a line, so NUL will terminate
         # This tests that write(binary) handles NUL correctly
         sleep(500ms);
-        *binary out = p.readStdoutBinary(100);
+        p.readStdoutBinary(100);
         # The actual behavior depends on how the child process handles binary
         # Just verify it doesn't crash
-        assertTrue(True, "Binary with NUL should not crash");
+        assertGe(0, p.id(), "Binary with NUL should not crash");
 
         p.write("0\n");
         if (!p.wait(10s)) {
@@ -1475,6 +1478,116 @@ public class Main inherits QUnit::Test {
             }});
             p.wait();
             assertEq(0, p.exitCode(), "process with multiple limits should succeed");
+        }
+    }
+
+    getCommandLineTest() {
+        if (HAVE_PROCESS_GETCOMMANDLINE) {
+            # Test getting command line for current process
+            {
+                string cmdline = Process::getCommandLine(getpid());
+                assertTrue(cmdline.size() > 0, "command line should not be empty");
+                # The command line should contain "qore" since we're running a qore script
+                assertTrue(cmdline.find("qore") >= 0,
+                    sprintf("command line should contain 'qore' (got '%s')", cmdline));
+            }
+
+            # Test getting command line for a child process with known arguments
+            {
+                Process p(getTestValue("testSleep"), (5,), {"path": (m_prefix,)});
+                string cmdline = Process::getCommandLine(p.id());
+                assertTrue(cmdline.size() > 0, "child command line should not be empty");
+                # The command line should contain the test script name
+                assertTrue(cmdline.find("test_sleep") >= 0,
+                    sprintf("child command line should contain 'test_sleep' (got '%s')", cmdline));
+                # The command line should contain the argument "5"
+                assertTrue(cmdline.find("5") >= 0,
+                    sprintf("child command line should contain argument '5' (got '%s')", cmdline));
+                p.terminate();
+            }
+
+            # Negative: invalid PID
+            assertThrows("PROCESS-GETCOMMANDLINE-ERROR", \Process::getCommandLine(), -1);
+
+            # Negative: nonexistent PID
+            assertThrows("PROCESS-GETCOMMANDLINE-ERROR", \Process::getCommandLine(), 999999999);
+        } else {
+            assertThrows("PROCESS-GETCOMMANDLINE-UNSUPPORTED-ERROR", \Process::getCommandLine(), 1);
+        }
+    }
+
+    getPidsForPortTest() {
+        if (HAVE_PROCESS_GETPIDSFORPORT) {
+            # Test with a TCP listener on a known port
+            {
+                Socket s();
+                # Bind to an ephemeral port
+                s.bind("localhost:0");
+                s.listen();
+                int port = s.getSocketInfo().port;
+                assertTrue(port > 0, sprintf("bind should assign a port (got %d)", port));
+
+                list<int> pids = Process::getPidsForPort(port);
+                assertTrue(pids.size() > 0,
+                    sprintf("should find at least one PID for port %d (got %y)", port, pids));
+                assertTrue(inlist(getpid(), pids),
+                    sprintf("current PID %d should be in the list for port %d (got %y)",
+                        getpid(), port, pids));
+            }
+
+            # Test unused port returns empty list
+            {
+                # Use a high ephemeral port that's very unlikely to be in use
+                list<int> pids = Process::getPidsForPort(59999);
+                # This might not be empty if something is actually listening, so just check type
+                assertTrue(exists pids, "should return a list");
+            }
+
+            # Negative: invalid port 0
+            assertThrows("PROCESS-GETPIDSFORPORT-ERROR", \Process::getPidsForPort(), 0);
+
+            # Negative: invalid port -1
+            assertThrows("PROCESS-GETPIDSFORPORT-ERROR", \Process::getPidsForPort(), -1);
+
+            # Negative: invalid port > 65535
+            assertThrows("PROCESS-GETPIDSFORPORT-ERROR", \Process::getPidsForPort(), 99999);
+        } else {
+            assertThrows("PROCESS-GETPIDSFORPORT-UNSUPPORTED-ERROR", \Process::getPidsForPort(), 80);
+        }
+    }
+
+    getPidsForUnixSocketTest() {
+        if (HAVE_PROCESS_GETPIDSFORUNIXSOCKET) {
+            # Test with a Unix domain socket listener
+            {
+                string sock_path = tmp_location() + DirSep + "process_test_" + get_random_string() + ".sock";
+                on_exit {
+                    try { unlink(sock_path); } catch () {}
+                }
+
+                Socket s();
+                s.bindUNIX(sock_path, SOCK_STREAM);
+                s.listen();
+
+                list<int> pids = Process::getPidsForUnixSocket(sock_path);
+                assertTrue(pids.size() > 0,
+                    sprintf("should find at least one PID for socket %s (got %y)", sock_path, pids));
+                assertTrue(inlist(getpid(), pids),
+                    sprintf("current PID %d should be in the list for socket %s (got %y)",
+                        getpid(), sock_path, pids));
+            }
+
+            # Test non-existent socket path returns empty list
+            {
+                list<int> pids = Process::getPidsForUnixSocket("/tmp/nonexistent_socket_path_12345.sock");
+                assertEq(0, pids.size(), "non-existent socket should return empty list");
+            }
+
+            # Negative: empty path
+            assertThrows("PROCESS-GETPIDSFORUNIXSOCKET-ERROR", \Process::getPidsForUnixSocket(), "");
+        } else {
+            assertThrows("PROCESS-GETPIDSFORUNIXSOCKET-UNSUPPORTED-ERROR",
+                \Process::getPidsForUnixSocket(), "/tmp/test.sock");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `Process::getCommandLine(pid)` to retrieve full command line of a process by PID using Boost ext::cmd; supported on Linux, macOS, FreeBSD, DragonFly, NetBSD, and OpenBSD; includes wall-clock-bounded retry with exponential backoff for transient empty cmdline during shebang exec chains
- Add `Process::getPidsForPort(port)` to find PIDs with listening TCP sockets on a given port; uses /proc/net/tcp on Linux, native libproc APIs on macOS, sysctl KERN_PROC_FILEDESC on FreeBSD/DragonFly
- Add `Process::getPidsForUnixSocket(path)` to find PIDs using a Unix domain socket; same platform coverage as getPidsForPort
- Link kvm library on BSD platforms for Boost ext::cmd support
- Feature detection constants (`HAVE_PROCESS_GETCOMMANDLINE`, `HAVE_PROCESS_GETPIDSFORPORT`, `HAVE_PROCESS_GETPIDSFORUNIXSOCKET`) and platform documentation

## Test plan
- [x] All 50 test cases pass (303 assertions) with `--enable-debug`
- [x] Valgrind clean: 0 bytes definitely/indirectly/possibly lost
- [ ] Verify on macOS CI
- [ ] Verify on Alpine/musl CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)